### PR TITLE
fix: correct transaction-log replay and Prometheus metrics

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"sync"
 	"syscall"
 	"time"
@@ -23,14 +24,39 @@ import (
 var transact *internal.TransactionLog
 var m *internal.Metrics
 
+// statusRecorder wraps http.ResponseWriter to capture the status code written
+// by the handler so it can be used as a Prometheus label.
+type statusRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func (rec *statusRecorder) WriteHeader(code int) {
+	rec.status = code
+	rec.ResponseWriter.WriteHeader(code)
+}
+
 // prometheusMiddleware implements mux.MiddlewareFunc + loggingMiddleware
 func prometheusLoggingMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		log.Println(r.Method, r.RequestURI)
-		//route := mux.CurrentRoute(r); path, _ := route.GetPathTemplate()
-		timer := prometheus.NewTimer(m.RequestDurationHistogram.WithLabelValues(r.Method, r.RequestURI))
-		next.ServeHTTP(w, r)
+
+		// Use the matched route template (e.g. "/v1/{key}") rather than the
+		// raw request URI to keep the label cardinality bounded; the raw URI
+		// embeds every key and would create an unbounded number of series.
+		path := r.URL.Path
+		if route := mux.CurrentRoute(r); route != nil {
+			if tmpl, err := route.GetPathTemplate(); err == nil {
+				path = tmpl
+			}
+		}
+
+		rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+		timer := prometheus.NewTimer(m.RequestDurationHistogram.WithLabelValues(r.Method, path))
+		next.ServeHTTP(rec, r)
 		timer.ObserveDuration()
+
+		m.RequestsTotal.WithLabelValues(strconv.Itoa(rec.status), r.Method).Inc()
 	})
 }
 
@@ -134,6 +160,11 @@ func initializeTransactionLog() error {
 		case err, ok = <-errors:
 
 		case e, ok = <-events:
+			if !ok {
+				// events channel closed: nothing left to replay, avoid
+				// counting the zero-value event delivered on close.
+				continue
+			}
 			switch e.EventType {
 			case internal.EventDelete: // Got a DELETE event!
 				err = internal.Delete(e.Key)
@@ -221,7 +252,9 @@ func main() {
 		log.Printf("Caught the following signal: %+v", sig)
 
 		log.Printf("Gracefully shutting down server..")
-		if err := srv.Shutdown(context.Background()); err != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := srv.Shutdown(ctx); err != nil {
 			log.Printf("Unable to shutdown server: %v", err)
 		} else {
 			log.Printf("Server stopped")

--- a/internal/metrics.go
+++ b/internal/metrics.go
@@ -64,7 +64,7 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 			Name:      "request_duration_seconds",
 			Help:      "Seconds spent serving HTTP requests.",
 			Buckets:   prometheus.DefBuckets,
-		}, []string{"code", "method"}), //[]string{"path"})
+		}, []string{"method", "path"}),
 	}
 	reg.MustRegister(m.Info)
 	reg.MustRegister(m.QueriesInflight)

--- a/internal/transact.go
+++ b/internal/transact.go
@@ -114,8 +114,6 @@ func (l *TransactionLog) ReadEvents() (<-chan Event, <-chan error) {
 	outError := make(chan error, 1)
 
 	go func() {
-		var e Event
-
 		defer close(outEvent)
 		defer close(outError)
 
@@ -126,6 +124,11 @@ func (l *TransactionLog) ReadEvents() (<-chan Event, <-chan error) {
 		}
 
 		for scanner.Scan() {
+			// Declared per line so an empty field (e.g. the value of a
+			// DELETE event) does not inherit the previous event's value,
+			// which fmt.Sscanf leaves untouched when it stops at EOF.
+			var e Event
+
 			line := scanner.Text()
 
 			n, err := fmt.Sscanf(

--- a/internal/transact_test.go
+++ b/internal/transact_test.go
@@ -151,6 +151,67 @@ func TestWritePut(t *testing.T) {
 	}
 }
 
+// TestDeleteEventHasNoStaleValue ensures a DELETE event replayed from the log
+// does not inherit the value of a preceding PUT event. fmt.Sscanf leaves the
+// value field untouched when it stops at the empty DELETE value, so the parsed
+// Event must be reset per line.
+func TestDeleteEventHasNoStaleValue(t *testing.T) {
+	tmpfile, err := os.CreateTemp("", "test-delete-stale")
+	if err != nil {
+		t.Fatalf("Cannot create temporary file: %v", err)
+	}
+	filename := tmpfile.Name()
+	if err := tmpfile.Close(); err != nil {
+		t.Fatalf("Failed to close temporary file: %v", err)
+	}
+	defer func() {
+		if err := os.Remove(filename); err != nil {
+			t.Logf("Failed to remove temporary file %s: %v", filename, err)
+		}
+	}()
+
+	writer, err := NewTransactionLogger(filename)
+	if err != nil {
+		t.Fatalf("Failed to create transaction logger: %v", err)
+	}
+	writer.Run()
+	writer.WritePut("my-key", "my-value")
+	writer.WriteDelete("my-key")
+	writer.Wait()
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Failed to close transaction logger: %v", err)
+	}
+
+	reader, err := NewTransactionLogger(filename)
+	if err != nil {
+		t.Fatalf("Failed to create read logger: %v", err)
+	}
+	defer func() {
+		if err := reader.Close(); err != nil {
+			t.Errorf("Failed to close read logger: %v", err)
+		}
+	}()
+
+	events, errs := reader.ReadEvents()
+	var got []Event
+	for e := range events {
+		got = append(got, e)
+	}
+	if err := <-errs; err != nil {
+		t.Fatalf("Error reading events: %v", err)
+	}
+
+	if len(got) != 2 {
+		t.Fatalf("Expected 2 events, got %d", len(got))
+	}
+	if got[1].EventType != EventDelete {
+		t.Fatalf("Expected second event to be DELETE, got type %d", got[1].EventType)
+	}
+	if got[1].Value != "" {
+		t.Errorf("DELETE event carries a stale value: got %q, want \"\"", got[1].Value)
+	}
+}
+
 func TestTransactionLoggerSimple(t *testing.T) {
 	// Create temporary file for testing
 	tmpfile, err := os.CreateTemp("", "test-transaction-log")

--- a/internal/version.go
+++ b/internal/version.go
@@ -7,7 +7,7 @@ import "fmt"
 
 // Version GitCommit BuiltDate are set at build-time
 var Version = "v0.0.1-SNAPSHOT"
-var GitCommit = "54a8d74ea3cf6fdcadfac10ee4a4f2553d4562f6q"
+var GitCommit = "54a8d74ea3cf6fdcadfac10ee4a4f2553d4562f6"
 var BuildDate = "Thu Jan  1 01:00:00 CET 1970" // date -r 0 (Mac), date -d @0 (Linux)
 
 func PrintVersion() {


### PR DESCRIPTION
- transact.go: reset the parsed Event per line in ReadEvents so a DELETE
  event no longer inherits the value of the preceding PUT. fmt.Sscanf
  leaves the value field untouched when it stops at the empty DELETE
  value, previously replaying stale data. Adds a regression test.
- metrics/server: the request-duration histogram was declared with
  {code,method} labels but called with (method, RequestURI), mislabeling
  values and using the raw URI as a label value (unbounded cardinality).
  Relabel to {method,path}, use the matched route template for path, and
  wire up the previously-unused RequestsTotal counter via a status-code
  capturing ResponseWriter.
- server.go: bound graceful shutdown with a 10s timeout context so a
  lingering connection cannot block shutdown forever; guard the replay
  loop against counting the zero-value event delivered on channel close.
- version.go: drop stray trailing character from the default GitCommit
  placeholder so it is a valid 40-char SHA.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MciAejuD6dmzgghxN9YqCh